### PR TITLE
refactor(dotnet): migrate pay-by-link to use Global Payments SDK

### DIFF
--- a/dotnet/Program.cs
+++ b/dotnet/Program.cs
@@ -1,31 +1,31 @@
 using dotenv.net;
-using System.Net;
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using GlobalPayments.Api;
+using GlobalPayments.Api.Entities;
+using GlobalPayments.Api.Entities.Enums;
+using GlobalPayments.Api.Services;
+using GlobalPayments.Api.ServiceConfigs;
+using GlobalPayments.Api.Entities.GpApi;
+using GlobalPayments.Api.Utils;
 
 namespace PayByLinkSample;
 
 /// <summary>
 /// Pay by Link Processing Application
 ///
-/// This application demonstrates payment link creation using the Global Payments API.
+/// This application demonstrates payment link creation using the Global Payments SDK.
 /// It provides endpoints for payment link creation, handling
 /// form data to create secure payment links that can be shared with customers.
 /// </summary>
 public class Program
 {
-    private static readonly HttpClient HttpClient = new HttpClient(new HttpClientHandler()
-    {
-        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-    });
-
     public static void Main(string[] args)
     {
         // Load environment variables from .env file
         DotEnv.Load();
+
+        // Configure the Global Payments SDK
+        ConfigureSdk();
 
         var builder = WebApplication.CreateBuilder(args);
 
@@ -41,6 +41,40 @@ public class Program
         app.Urls.Add($"http://0.0.0.0:{port}");
 
         app.Run();
+    }
+
+    /// <summary>
+    /// Configure the Global Payments SDK
+    ///
+    /// Sets up the Global Payments SDK with necessary credentials and settings
+    /// loaded from environment variables.
+    /// </summary>
+    private static void ConfigureSdk()
+    {
+        var appId = System.Environment.GetEnvironmentVariable("GP_API_APP_ID");
+        var appKey = System.Environment.GetEnvironmentVariable("GP_API_APP_KEY");
+
+        if (string.IsNullOrEmpty(appId) || string.IsNullOrEmpty(appKey))
+        {
+            throw new InvalidOperationException("Missing GP_API_APP_ID or GP_API_APP_KEY environment variables");
+        }
+
+        var config = new GpApiConfig
+        {
+            AppId = appId,
+            AppKey = appKey,
+            Environment = GlobalPayments.Api.Entities.Environment.TEST, // Use Environment.PRODUCTION for live transactions
+            Channel = Channel.CardNotPresent,
+            Country = "GB"
+        };
+
+        // Set up access token info for Pay by Link
+        config.AccessTokenInfo = new AccessTokenInfo
+        {
+            TransactionProcessingAccountName = "paylink"
+        };
+
+        ServicesContainer.ConfigureService(config);
     }
 
     /// <summary>
@@ -80,130 +114,6 @@ public class Program
 
         // Limit length to 100 characters
         return sanitized.Length > 100 ? sanitized[..100] : sanitized;
-    }
-
-    /// <summary>
-    /// Generates a secret hash using SHA512 for GP API authentication.
-    /// The secret is created as SHA512(NONCE + APP-KEY).
-    /// </summary>
-    /// <param name="nonce">The nonce value</param>
-    /// <param name="appKey">The application key</param>
-    /// <returns>SHA512 hash as lowercase hex string</returns>
-    private static string GenerateSecret(string nonce, string appKey)
-    {
-        var data = Encoding.UTF8.GetBytes(nonce + appKey);
-
-        using var sha512 = SHA512.Create();
-        var hash = sha512.ComputeHash(data);
-
-        var sb = new StringBuilder(128);
-        foreach (var b in hash)
-        {
-            sb.Append(b.ToString("X2"));
-        }
-
-        return sb.ToString().ToLower();
-    }
-
-    /// <summary>
-    /// Generates an access token for GP API using app credentials.
-    /// </summary>
-    /// <returns>GP API token response</returns>
-    private static async Task<GpApiTokenResponse?> GenerateAccessToken()
-    {
-        var appId = System.Environment.GetEnvironmentVariable("GP_API_APP_ID");
-        var appKey = System.Environment.GetEnvironmentVariable("GP_API_APP_KEY");
-
-        if (string.IsNullOrEmpty(appId) || string.IsNullOrEmpty(appKey))
-        {
-            throw new InvalidOperationException("Missing GP_API_APP_ID or GP_API_APP_KEY environment variables");
-        }
-
-        var nonce = DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss.fff tt");
-
-        var tokenRequest = new GpApiTokenRequest
-        {
-            AppId = appId,
-            Nonce = nonce,
-            GrantType = "client_credentials",
-            Secret = GenerateSecret(nonce, appKey)
-        };
-
-        var requestJson = JsonSerializer.Serialize(tokenRequest);
-        var content = new StringContent(requestJson, System.Text.Encoding.UTF8, "application/json");
-
-        using var request = new HttpRequestMessage(HttpMethod.Post, "https://apis.sandbox.globalpay.com/ucp/accesstoken");
-        request.Content = content;
-        request.Headers.Add("X-GP-Api-Key", appKey);
-        request.Headers.Add("X-GP-Version", "2021-03-22");
-        request.Headers.Add("Accept", "application/json");
-        request.Headers.Add("User-Agent", "PayByLink-DotNet/1.0");
-
-        var response = await HttpClient.SendAsync(request);
-        var responseContent = await response.Content.ReadAsStringAsync();
-
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException($"Token request failed with status {response.StatusCode}: {responseContent}");
-        }
-
-        return JsonSerializer.Deserialize<GpApiTokenResponse>(responseContent);
-    }
-
-    /// <summary>
-    /// Creates a payment link via direct GP API call.
-    /// </summary>
-    /// <param name="paymentLinkData">Payment link data</param>
-    /// <param name="accessToken">Access token for authentication</param>
-    /// <returns>Payment link response</returns>
-    private static async Task<GpApiLinkResponse?> CreatePaymentLink(PaymentLinkData paymentLinkData, string accessToken)
-    {
-        var requestJson = JsonSerializer.Serialize(paymentLinkData, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
-        });
-
-        var content = new StringContent(requestJson, System.Text.Encoding.UTF8, "application/json");
-
-        using var request = new HttpRequestMessage(HttpMethod.Post, "https://apis.sandbox.globalpay.com/ucp/links");
-        request.Content = content;
-        request.Headers.Add("Authorization", $"Bearer {accessToken}");
-        request.Headers.Add("X-GP-Version", "2021-03-22");
-        request.Headers.Add("Accept", "application/json");
-        request.Headers.Add("User-Agent", "PayByLink-DotNet/1.0");
-
-        var response = await HttpClient.SendAsync(request);
-        var responseContent = await response.Content.ReadAsStringAsync();
-
-        if (!response.IsSuccessStatusCode)
-        {
-            // Try to parse error response for better error details
-            string errorMsg;
-            try
-            {
-                using var errorDoc = JsonDocument.Parse(responseContent);
-                if (errorDoc.RootElement.TryGetProperty("error_description", out var errorDesc))
-                {
-                    errorMsg = errorDesc.GetString() ?? responseContent;
-                }
-                else if (errorDoc.RootElement.TryGetProperty("message", out var message))
-                {
-                    errorMsg = message.GetString() ?? responseContent;
-                }
-                else
-                {
-                    errorMsg = responseContent;
-                }
-            }
-            catch
-            {
-                errorMsg = responseContent;
-            }
-
-            throw new InvalidOperationException($"Payment link creation failed with status {response.StatusCode}: {errorMsg}");
-        }
-
-        return JsonSerializer.Deserialize<GpApiLinkResponse>(responseContent);
     }
 
     /// <summary>
@@ -258,84 +168,41 @@ public class Program
 
                 var currency = form["currency"].ToString().Trim().ToUpper();
 
-                // Generate access token
-                var tokenResponse = await GenerateAccessToken();
-                if (tokenResponse == null)
+                // Create PayByLinkData object following the test pattern
+                var payByLink = new PayByLinkData
                 {
-                    return Results.BadRequest(new {
-                        success = false,
-                        message = "Payment link creation failed",
-                        error = new {
-                            code = "TOKEN_GENERATION_ERROR",
-                            details = "Failed to generate access token"
-                        }
-                    });
-                }
-
-                // Set account name from token response or default to "paylink"
-                var accountName = !string.IsNullOrEmpty(tokenResponse.TransactionProcessingAccountName)
-                    ? tokenResponse.TransactionProcessingAccountName
-                    : "paylink";
-
-                // Create PayByLink data object
-                var expirationDate = DateTime.Now.AddDays(10).ToString("yyyy-MM-dd HH:mm:ss");
-
-                var payByLinkData = new PaymentLinkData
-                {
-                    AccountName = accountName,
-                    Type = "PAYMENT",  // PayByLinkType::PAYMENT
-                    UsageMode = "SINGLE",   // PaymentMethodUsageMode::SINGLE
-                    UsageLimit = 1,          // usageLimit = 1
-                    Reference = reference,
+                    Type = PayByLinkType.PAYMENT,
+                    UsageMode = PaymentMethodUsageMode.Single,
+                    AllowedPaymentMethods = new[] { PaymentMethodName.Card },
+                    UsageLimit = 1,
                     Name = name,
-                    Description = description,
-                    Shippable = "YES",
-                    ShippingAmount = 0,         // shippingAmount = 0
-                    ExpirationDate = expirationDate, // +10 days
-                    Transactions = new PaymentLinkTransactions
-                    {
-                        AllowedPaymentMethods = ["CARD"], // allowedPaymentMethods = [PaymentMethodName::CARD]
-                        Channel = "CNP",             // Card Not Present
-                        Country = "GB",
-                        Amount = amount,            // Amount in cents
-                        Currency = currency
-                    },
-                    Notifications = new PaymentLinkNotifications
-                    {
-                        ReturnUrl = "https://www.example.com/returnUrl",  // returnUrl
-                        StatusUrl = "https://www.example.com/statusUrl",  // statusUpdateUrl
-                        CancelUrl = "https://www.example.com/returnUrl"   // cancelUrl
-                    }
+                    IsShippable = true,
+                    ShippingAmount = 0m,
+                    ExpirationDate = DateTime.UtcNow.AddDays(10),
+                    Images = Array.Empty<string>(),
+                    ReturnUrl = "https://www.example.com/returnUrl",
+                    StatusUpdateUrl = "https://www.example.com/statusUrl",
+                    CancelUrl = "https://www.example.com/returnUrl"
                 };
 
-                // Add merchant_id if available
-                if (!string.IsNullOrEmpty(tokenResponse.MerchantId))
-                {
-                    payByLinkData.MerchantId = tokenResponse.MerchantId;
-                }
+                // Create the payment link using PayByLinkService (amount in dollars)
+                var response = PayByLinkService.Create(payByLink, amount / 100m)
+                    .WithCurrency(currency)
+                    .WithClientTransactionId(GenerationUtils.GenerateRecurringKey())
+                    .WithDescription(description)
+                    .Execute();
 
-                // Create payment link via GP API
-                var linkResponse = await CreatePaymentLink(payByLinkData, tokenResponse.Token);
-                if (linkResponse == null || string.IsNullOrEmpty(linkResponse.Url))
-                {
-                    return Results.BadRequest(new {
-                        success = false,
-                        message = "Payment link creation failed",
-                        error = new {
-                            code = "INVALID_RESPONSE",
-                            details = "No payment link URL in response"
-                        }
-                    });
-                }
+                // Extract payment link URL from response
+                var paymentLink = response.PayByLinkResponse.Url;
 
-                // Return success response
+                // Return success response with payment link details
                 return Results.Ok(new
                 {
                     success = true,
-                    message = $"Payment link created successfully! Link ID: {linkResponse.Id}",
+                    message = $"Payment link created successfully! Link ID: {response.PayByLinkResponse.Id}",
                     data = new {
-                        paymentLink = linkResponse.Url,
-                        linkId = linkResponse.Id,
+                        paymentLink = paymentLink,
+                        linkId = response.PayByLinkResponse.Id,
                         reference = reference,
                         amount = amount,
                         currency = currency
@@ -344,156 +211,16 @@ public class Program
             }
             catch (Exception ex)
             {
-                // Determine error code based on exception type/message
-                string errorCode = "UNKNOWN_ERROR";
-                if (ex.Message.Contains("Failed to generate access token") || ex.Message.Contains("Token request failed"))
-                {
-                    errorCode = "TOKEN_GENERATION_ERROR";
-                }
-                else if (ex.Message.Contains("Payment link creation failed") || ex.Message.Contains("Invalid response"))
-                {
-                    errorCode = "API_ERROR";
-                }
-
+                // Handle payment link creation errors
                 return Results.BadRequest(new {
                     success = false,
                     message = "Payment link creation failed",
                     error = new {
-                        code = errorCode,
+                        code = "API_ERROR",
                         details = ex.Message
                     }
                 });
             }
         });
     }
-}
-
-// Data models for GP API communication
-public class GpApiTokenRequest
-{
-    [JsonPropertyName("app_id")]
-    public string AppId { get; set; } = "";
-
-    [JsonPropertyName("nonce")]
-    public string Nonce { get; set; } = "";
-
-    [JsonPropertyName("grant_type")]
-    public string GrantType { get; set; } = "";
-
-    [JsonPropertyName("secret")]
-    public string Secret { get; set; } = "";
-}
-
-public class GpApiTokenResponse
-{
-    [JsonPropertyName("token")]
-    public string Token { get; set; } = "";
-
-    [JsonPropertyName("type")]
-    public string Type { get; set; } = "";
-
-    [JsonPropertyName("app_id")]
-    public string AppId { get; set; } = "";
-
-    [JsonPropertyName("app_name")]
-    public string AppName { get; set; } = "";
-
-    [JsonPropertyName("time_created")]
-    public string TimeCreated { get; set; } = "";
-
-    [JsonPropertyName("seconds_to_expire")]
-    public int SecondsToExpire { get; set; }
-
-    [JsonPropertyName("email")]
-    public string Email { get; set; } = "";
-
-    [JsonPropertyName("merchant_id")]
-    public string MerchantId { get; set; } = "";
-
-    [JsonPropertyName("merchant_name")]
-    public string MerchantName { get; set; } = "";
-
-    [JsonPropertyName("transaction_processing_account_name")]
-    public string TransactionProcessingAccountName { get; set; } = "";
-}
-
-public class PaymentLinkData
-{
-    [JsonPropertyName("account_name")]
-    public string AccountName { get; set; } = "";
-
-    [JsonPropertyName("type")]
-    public string Type { get; set; } = "";
-
-    [JsonPropertyName("usage_mode")]
-    public string UsageMode { get; set; } = "";
-
-    [JsonPropertyName("usage_limit")]
-    public int UsageLimit { get; set; }
-
-    [JsonPropertyName("reference")]
-    public string Reference { get; set; } = "";
-
-    [JsonPropertyName("name")]
-    public string Name { get; set; } = "";
-
-    [JsonPropertyName("description")]
-    public string Description { get; set; } = "";
-
-    [JsonPropertyName("shippable")]
-    public string Shippable { get; set; } = "";
-
-    [JsonPropertyName("shipping_amount")]
-    public int ShippingAmount { get; set; }
-
-    [JsonPropertyName("expiration_date")]
-    public string ExpirationDate { get; set; } = "";
-
-    [JsonPropertyName("transactions")]
-    public PaymentLinkTransactions Transactions { get; set; } = new();
-
-    [JsonPropertyName("notifications")]
-    public PaymentLinkNotifications Notifications { get; set; } = new();
-
-    [JsonPropertyName("merchant_id")]
-    public string? MerchantId { get; set; }
-}
-
-public class PaymentLinkTransactions
-{
-    [JsonPropertyName("allowed_payment_methods")]
-    public string[] AllowedPaymentMethods { get; set; } = [];
-
-    [JsonPropertyName("channel")]
-    public string Channel { get; set; } = "";
-
-    [JsonPropertyName("country")]
-    public string Country { get; set; } = "";
-
-    [JsonPropertyName("amount")]
-    public int Amount { get; set; }
-
-    [JsonPropertyName("currency")]
-    public string Currency { get; set; } = "";
-}
-
-public class PaymentLinkNotifications
-{
-    [JsonPropertyName("return_url")]
-    public string ReturnUrl { get; set; } = "";
-
-    [JsonPropertyName("status_url")]
-    public string StatusUrl { get; set; } = "";
-
-    [JsonPropertyName("cancel_url")]
-    public string CancelUrl { get; set; } = "";
-}
-
-public class GpApiLinkResponse
-{
-    [JsonPropertyName("id")]
-    public string Id { get; set; } = "";
-
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = "";
 }


### PR DESCRIPTION
Replace direct HTTP API calls with GlobalPayments.Api SDK for payment link creation. This brings the .NET implementation in line with the PHP implementation pattern and official SDK best practices.

Changes:
- Add SDK configuration using GpApiConfig with AccessTokenInfo
- Replace manual token generation and API requests with PayByLinkService
- Remove custom data models in favor of SDK entities
- Use SDK enums (PayByLinkType, PaymentMethodUsageMode, PaymentMethodName)
- Simplify payment link creation with fluent builder API
- Remove ~300 lines of manual HTTP handling code